### PR TITLE
Overcoming macOS 10.15 strictness

### DIFF
--- a/src/jet/live/Utility.cpp
+++ b/src/jet/live/Utility.cpp
@@ -183,6 +183,8 @@ namespace jet
                     .append(" -Wl,-install_name,")
                     .append(libName)
                     .append(" -Wl,-flat_namespace")
+                    .append(" -Wl,-rename_section,__TEXT,__text,__JET_TEXT,__text")
+                    .append(" -Wl,-segprot,__JET_TEXT,rwx,rwx")
                     .append(" -undefined dynamic_lookup");
                 break;
             }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -66,6 +66,7 @@ target_sources(tests
   src/utility/ReloadAfterFailedCompilation1.cpp
   src/utility/ReloadAfterFailedCompilation2.cpp
   src/utility/OneFrameCompileReload.cpp
+  src/utility/MacosFunctionOutOfScope.cpp
 
   src/good/ClassInstanceMethod_test.cpp
   src/good/CommonSection_test.cpp
@@ -99,6 +100,7 @@ target_sources(tests
   src/good/LostModification_test.cpp
   src/good/ReloadAfterFailedCompilation_test.cpp
   src/good/OneFrameCompileReload_test.cpp
+  src/good/MacosFunctionOutOfScope_test.cpp
 
   src/bad/LambdaFunctionWithCapturesBadCase2_test.cpp
   src/bad/LambdaFunctionWithCapturesBadCase_test.cpp

--- a/tests/src/good/MacosFunctionOutOfScope_test.cpp
+++ b/tests/src/good/MacosFunctionOutOfScope_test.cpp
@@ -1,0 +1,22 @@
+
+#include <catch.hpp>
+#include <iostream>
+#include <thread>
+#include "utility/MacosFunctionOutOfScope.hpp"
+#include "Globals.hpp"
+#include "WaitForReload.hpp"
+
+TEST_CASE("Function address is out of readable memory", "[function]")
+{
+    REQUIRE(getStdStringValue() == "some string");
+
+    std::cout << "JET_TEST: disable(fun_out_of_scope:1); enable(fun_out_of_scope:2)" << std::endl;
+    waitForReload();
+
+    REQUIRE(getStdStringValue() == "some another string");
+    
+    std::cout << "JET_TEST: disable(fun_out_of_scope:2); enable(fun_out_of_scope:1)" << std::endl;
+    waitForReload();
+
+    REQUIRE(getStdStringValue() == "some string");
+}

--- a/tests/src/utility/MacosFunctionOutOfScope.cpp
+++ b/tests/src/utility/MacosFunctionOutOfScope.cpp
@@ -1,0 +1,10 @@
+
+#include "MacosFunctionOutOfScope.hpp"
+
+std::string getStdStringValue()
+{
+    std::string stringValue = "some "; // <jet_tag: fun_out_of_scope:1>
+//    std::string stringValue = "some another "; // <jet_tag: fun_out_of_scope:2>
+    stringValue += "string";
+    return stringValue;
+}

--- a/tests/src/utility/MacosFunctionOutOfScope.hpp
+++ b/tests/src/utility/MacosFunctionOutOfScope.hpp
@@ -1,0 +1,6 @@
+
+#pragma once
+
+#include <string>
+
+std::string getStdStringValue();


### PR DESCRIPTION
To overcome macOS 10.15 strictness to the __TEXT segment protection flags we're moving __TEXT.__text section to the new one and setting needed access rights to it to be able to modify it in runtime.
Adressing #40 