### PR TITLE
Add option for listeners to filter compilation units

### DIFF
--- a/src/jet/live/CompileCommandsCompilationUnitsParser.cpp
+++ b/src/jet/live/CompileCommandsCompilationUnitsParser.cpp
@@ -171,7 +171,11 @@ namespace jet
             }
 
             cu.compilerPath = parser[0];
-            res[cu.sourceFilePath] = cu;
+
+            if (context->listener->filterCompilationUnit(cu)) {
+                res[cu.sourceFilePath] = cu;
+            }
+
             wordfree(&result);
         }
 

--- a/src/jet/live/ILiveListener.hpp
+++ b/src/jet/live/ILiveListener.hpp
@@ -5,6 +5,8 @@
 
 namespace jet
 {
+    struct CompilationUnit;
+
     enum class LogSeverity
     {
         kDebug,
@@ -35,5 +37,11 @@ namespace jet
          * Called right after all functions are hooked and state is transferred.
          */
         virtual void onCodePostLoad() {}
+
+        /**
+         * Allows the application to select which compilation unit to consider when parsing compile_commands.json.
+         * Return true if the compilation unit should be considered (default), or false if it should be discarded.
+         */
+        virtual bool filterCompilationUnit(const CompilationUnit&) { return true; }
     };
 }


### PR DESCRIPTION
# Description
Allows applications to select which compilation units are monitored by jet-live.
If an application rejects a given compilation unit, this file will not be watched nor the object will be recompiled when changed. By default, all files are monitored (as it is before this PR)

# Motivation
My project has different CMake targets when enabling AddressSanitizer, so my source files are the same between the ASAN and non-ASAN targets.
However, jet-live maps compilation arguments to the source filename. This creates an issue when trying to reload my source files because the ASAN compilation command is last inside my compile_commands.json file. Jet-live will override the non-ASAN version with the ASAN version of my compilation unit (in CompileCommandsCompilationUnitsParser.cpp), making jet-live compile the ASAN version, and failing to link it into the running non-ASAN executable.

Extract from my compile_commands.json file:
```json
{
  "directory": "/mnt/StockageSSD/Programming/Games/Carrot/cmake-build-debug-ninja",
  "command": "/usr/bin/c++ [...] -o engine/CMakeFiles/Engine-Base.dir/engine/render/RenderGraph.cpp.o -c /mnt/StockageSSD/Programming/Games/Carrot/engine/engine/render/RenderGraph.cpp",
  "file": "/mnt/StockageSSD/Programming/Games/Carrot/engine/engine/render/RenderGraph.cpp",
  "output": "engine/CMakeFiles/Engine-Base.dir/engine/render/RenderGraph.cpp.o"
},
[...]
{
  "directory": "/mnt/StockageSSD/Programming/Games/Carrot/cmake-build-debug-ninja",
  "command": "/usr/bin/c++ [...] -fsanitize=address [...] -o engine/CMakeFiles/Engine-ASAN.dir/engine/render/RenderGraph.cpp.o -c /mnt/StockageSSD/Programming/Games/Carrot/engine/engine/render/RenderGraph.cpp",
  "file": "/mnt/StockageSSD/Programming/Games/Carrot/engine/engine/render/RenderGraph.cpp",
  "output": "engine/CMakeFiles/Engine-ASAN.dir/engine/render/RenderGraph.cpp.o"
},

```

From what I have seen, it is not possible to know which .o files are used to build a given executable (without modifications to the toolchain). Therefore, to minimize required changes to the toolchain of applications using jet-live, I have decided to create a hook to let the application reject some files if need be.

Example usage here: https://codeberg.org/jglrxavpok/Carrot/commit/582e5c701f78bff4150113a6ad32cacb5734b43e