### PR TITLE
Parse compile_commands without wordexp() to speed up init

### DIFF
--- a/src/jet/live/CompileCommandsCompilationUnitsParser.cpp
+++ b/src/jet/live/CompileCommandsCompilationUnitsParser.cpp
@@ -5,7 +5,6 @@
 #include <json.hpp>
 #include <process.hpp>
 #include <teenypath.h>
-#include <wordexp.h>
 #include "jet/live/BuildConfig.hpp"
 #include "jet/live/DataTypes.hpp"
 #include "jet/live/LiveContext.hpp"
@@ -13,6 +12,52 @@
 
 namespace jet
 {
+    namespace
+    {
+        // Split a shell-escaped compile command (the compile_commands.json "command" field) into argv.
+        // Replaces wordexp(), which fork+exec'd /bin/sh for every compilation unit — dominating init
+        // time on large projects — and additionally performed command substitution ($(...)). The
+        // command is a resolved, shell-escaped string, so a quote/escape-aware split yields the same
+        // tokens without a shell. Honors '...', "..." and backslash escapes (POSIX sh rules).
+        std::vector<std::string> tokenizeCommand(const std::string& cmd)
+        {
+            std::vector<std::string> tokens;
+            std::string cur;
+            bool inToken = false;
+            char quote = 0;  // 0 = none, or '\'' / '"'
+            for (size_t i = 0; i < cmd.size(); ++i) {
+                const char c = cmd[i];
+                if (quote == '\'') {
+                    if (c == '\'') { quote = 0; } else { cur += c; }
+                    inToken = true;
+                } else if (quote == '"') {
+                    if (c == '"') {
+                        quote = 0;
+                    } else if (c == '\\' && i + 1 < cmd.size()
+                        && (cmd[i + 1] == '"' || cmd[i + 1] == '\\' || cmd[i + 1] == '$' || cmd[i + 1] == '`')) {
+                        cur += cmd[++i];
+                    } else {
+                        cur += c;
+                    }
+                    inToken = true;
+                } else if (c == ' ' || c == '\t' || c == '\n' || c == '\r') {
+                    if (inToken) { tokens.push_back(cur); cur.clear(); inToken = false; }
+                } else if (c == '\'' || c == '"') {
+                    quote = c;
+                    inToken = true;
+                } else if (c == '\\' && i + 1 < cmd.size()) {
+                    cur += cmd[++i];
+                    inToken = true;
+                } else {
+                    cur += c;
+                    inToken = true;
+                }
+            }
+            if (inToken) { tokens.push_back(cur); }
+            return tokens;
+        }
+    }  // namespace
+
     std::vector<std::string> CompileCommandsCompilationUnitsParser::getFilesToMonitor() const
     {
         std::vector<std::string> res;
@@ -144,20 +189,17 @@ namespace jet
                 continue;
             }
 
-            wordexp_t result;
-            switch (wordexp(cu.compilationCommandStr.c_str(), &result, 0)) {
-                case 0: break;
-                case WRDE_NOSPACE: wordfree(&result); continue;
-                default: continue;
-            }
+            std::vector<std::string> tokens = tokenizeCommand(cu.compilationCommandStr);
+            std::vector<char*> argv;
+            argv.reserve(tokens.size());
+            for (auto& tok : tokens) { argv.push_back(tok.data()); }
 
             argh::parser parser(
-                static_cast<int>(result.we_wordc), result.we_wordv, argh::parser::PREFER_PARAM_FOR_UNREG_OPTION);
+                static_cast<int>(argv.size()), argv.data(), argh::parser::PREFER_PARAM_FOR_UNREG_OPTION);
             cu.objFilePath = parser({"-o", "--output"}).str();
             if (cu.objFilePath.empty()) {
                 context->events->addLog(
                     LogSeverity::kWarning, "Cannot find object file path, skipping: " + cu.sourceFilePath);
-                wordfree(&result);
                 continue;
             }
             cu.hasColorDiagnosticsFlag = parser[{"-fcolor-diagnostics"}];
@@ -175,8 +217,6 @@ namespace jet
             if (context->listener->filterCompilationUnit(cu)) {
                 res[cu.sourceFilePath] = cu;
             }
-
-            wordfree(&result);
         }
 
         return res;


### PR DESCRIPTION
## Problem

`CompileCommandsCompilationUnitsParser` calls `wordexp()` on the `command` field of **every**
compile_commands.json entry, only to split it into argv (to read `-o` / `-MF` / the compiler /
`-fcolor-diagnostics`). `wordexp()` fork+exec's `/bin/sh` once per entry, which dominates startup on
large projects — on a ~12k-entry database this was ~135s (vs a couple of seconds for actual symbol
loading). It also performs shell command substitution `$(...)`, which is unnecessary (and unsafe) for
parsing a DB.

## Fix

Replace `wordexp()` with a small quote/escape-aware tokenizer. Per the compile_commands.json spec the
`command` is a resolved, shell-escaped string, so a plain tokenizer yields the same argv without
spawning a shell. The recompile still runs the original command string through the shell
(`Compiler.cpp`), so no shell-expansion behavior is lost — the tokens are only used for field
extraction.

## Result

Init time on a large monolithic project dropped from ~135s to a few seconds; zero shell forks.

## Notes

- Honors `'...'`, `"..."`, and backslash escapes (POSIX sh rules); validated on a ~2.9k-entry DB
  (both first-party and third-party TUs recompiled/reloaded correctly).
- Portable C++17, no platform APIs — `wordexp` was POSIX-only, so this also broadens portability.
- Drops the `<wordexp.h>` dependency.
